### PR TITLE
Example makefile improvements

### DIFF
--- a/examples/hello-lambda/Makefile
+++ b/examples/hello-lambda/Makefile
@@ -50,10 +50,10 @@ pack:
 deploy:
 	@sam deploy --template-file ./packaged.yaml --stack-name $(STACK_NAME) --capabilities CAPABILITY_IAM --region $(APP_REGION)
 
-native-pack:
+native-pack: native-compile
 	@sam package --template-file ./resources/native-template.yml --output-template-file resources/native-packaged.yaml --s3-bucket $(BUCKET_NAME) --s3-prefix "hello-lambda-latest"
 
-native-deploy:
+native-deploy: native-pack
 	@sam deploy --template-file ./resources/native-packaged.yaml --stack-name $(STACK_NAME) --capabilities CAPABILITY_IAM --region $(APP_REGION)
 
 native-destroy:
@@ -61,3 +61,6 @@ native-destroy:
 
 logs-tail:
 	sam logs -n $(LAMBDA_NAME) --stack-name $(STACK_NAME) -t
+
+native-invoke:
+	sam local invoke $(LAMBDA_NAME) --template ./resources/native-template.yml --skip-pull-image -e $(EVENT_PAYLOAD_FILE)

--- a/examples/hello-lambda/Makefile
+++ b/examples/hello-lambda/Makefile
@@ -44,10 +44,10 @@ native-compile: compile
 native-dry-api:
 	@sam local start-api --template ./resources/native-template.yml --skip-pull-image
 
-pack:
+pack: compile
 	@sam package --template-file ./template.yml --output-template-file packaged.yaml --s3-bucket $(BUCKET_NAME) --s3-prefix "hello-lambda-latest"
 
-deploy:
+deploy: pack
 	@sam deploy --template-file ./packaged.yaml --stack-name $(STACK_NAME) --capabilities CAPABILITY_IAM --region $(APP_REGION)
 
 native-pack: native-compile

--- a/examples/hello-lambda/Makefile
+++ b/examples/hello-lambda/Makefile
@@ -65,5 +65,10 @@ logs-tail:
 native-invoke:
 	sam local invoke $(LAMBDA_NAME) --template ./resources/native-template.yml --skip-pull-image -e $(EVENT_PAYLOAD_FILE)
 
-clean:
+delete:
+	aws cloudformation delete-stack --stack-name holy-lambda--hello-lambda
+
+clean: delete
 	-rm -rf target/
+	-rm packaged.yml
+	-rm resources/native-packaged.yml

--- a/examples/hello-lambda/Makefile
+++ b/examples/hello-lambda/Makefile
@@ -3,7 +3,7 @@ GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
 NC='\033[0m'
 
-.PHONY: install-holy-lambda native-dry-run compile dry-run native-compile native-pack native-deploy native-destroy logs-tail
+.PHONY: install-holy-lambda native-dry-run compile dry-run native-compile native-pack native-deploy native-destroy logs-tail clean destroy
 BUCKET_NAME=holy-lambda--hello-lambda
 STACK_NAME=holy-lambda--hello-lambda
 APP_REGION=eu-central-1
@@ -56,7 +56,7 @@ native-pack: native-compile make-bucket
 native-deploy: native-pack
 	@sam deploy --template-file ./resources/native-packaged.yml --stack-name $(STACK_NAME) --capabilities CAPABILITY_IAM --region $(APP_REGION)
 
-native-destroy:
+destroy:
 	@aws cloudformation delete-stack --stack-name $(STACK_NAME) --region $(APP_REGION)
 
 logs-tail:
@@ -65,10 +65,7 @@ logs-tail:
 native-invoke:
 	sam local invoke $(LAMBDA_NAME) --template ./resources/native-template.yml --skip-pull-image -e $(EVENT_PAYLOAD_FILE)
 
-delete:
-	aws cloudformation delete-stack --stack-name holy-lambda--hello-lambda
-
-clean: delete
+clean: destroy
 	-rm -rf target/
 	-rm packaged.yml
 	-rm resources/native-packaged.yml

--- a/examples/hello-lambda/Makefile
+++ b/examples/hello-lambda/Makefile
@@ -64,3 +64,6 @@ logs-tail:
 
 native-invoke:
 	sam local invoke $(LAMBDA_NAME) --template ./resources/native-template.yml --skip-pull-image -e $(EVENT_PAYLOAD_FILE)
+
+clean:
+	-rm -rf target/

--- a/examples/hello-lambda/Makefile
+++ b/examples/hello-lambda/Makefile
@@ -45,16 +45,16 @@ native-dry-api:
 	@sam local start-api --template ./resources/native-template.yml --skip-pull-image
 
 pack: compile make-bucket
-	@sam package --template-file ./template.yml --output-template-file packaged.yaml --s3-bucket $(BUCKET_NAME) --s3-prefix "hello-lambda-latest"
+	@sam package --template-file ./template.yml --output-template-file packaged.yml --s3-bucket $(BUCKET_NAME) --s3-prefix "hello-lambda-latest"
 
 deploy: pack
-	@sam deploy --template-file ./packaged.yaml --stack-name $(STACK_NAME) --capabilities CAPABILITY_IAM --region $(APP_REGION)
+	@sam deploy --template-file ./packaged.yml --stack-name $(STACK_NAME) --capabilities CAPABILITY_IAM --region $(APP_REGION)
 
 native-pack: native-compile make-bucket
-	@sam package --template-file ./resources/native-template.yml --output-template-file resources/native-packaged.yaml --s3-bucket $(BUCKET_NAME) --s3-prefix "hello-lambda-latest"
+	@sam package --template-file ./resources/native-template.yml --output-template-file resources/native-packaged.yml --s3-bucket $(BUCKET_NAME) --s3-prefix "hello-lambda-latest"
 
 native-deploy: native-pack
-	@sam deploy --template-file ./resources/native-packaged.yaml --stack-name $(STACK_NAME) --capabilities CAPABILITY_IAM --region $(APP_REGION)
+	@sam deploy --template-file ./resources/native-packaged.yml --stack-name $(STACK_NAME) --capabilities CAPABILITY_IAM --region $(APP_REGION)
 
 native-destroy:
 	@aws cloudformation delete-stack --stack-name $(STACK_NAME) --region $(APP_REGION)

--- a/examples/hello-lambda/Makefile
+++ b/examples/hello-lambda/Makefile
@@ -27,7 +27,7 @@ dry-api:
 gen-native-configuration:
 	@choly graal -e "java -agentlib:native-image-agent=config-output-dir=resources/native-configuration -Dexecutor=native-agent -jar target/output.jar"
 
-native-compile:
+native-compile: compile
 	@choly template -t template.yml
 	@choly graal -e "native-image -jar target/output.jar \
 			--report-unsupported-elements-at-runtime \

--- a/examples/hello-lambda/Makefile
+++ b/examples/hello-lambda/Makefile
@@ -10,7 +10,7 @@ APP_REGION=eu-central-1
 LAMBDA_NAME=HelloLambdaFunction
 
 make-bucket:
-	@aws s3 ls s3://holy-lambda--hello-lambda || aws s3 mb s3://$(BUCKET_NAME)
+	@aws s3 ls s3://$(BUCKET_NAME) || aws s3 mb s3://$(BUCKET_NAME)
 
 destroy-bucket:
 	@aws s3 rb s3://$(BUCKET_NAME) --force --region $(APP_REGION)

--- a/examples/hello-lambda/Makefile
+++ b/examples/hello-lambda/Makefile
@@ -10,7 +10,7 @@ APP_REGION=eu-central-1
 LAMBDA_NAME=HelloLambdaFunction
 
 make-bucket:
-	@aws s3 mb s3://$(BUCKET_NAME)
+	@aws s3 ls s3://holy-lambda--hello-lambda || aws s3 mb s3://$(BUCKET_NAME)
 
 destroy-bucket:
 	@aws s3 rb s3://$(BUCKET_NAME) --force --region $(APP_REGION)
@@ -44,13 +44,13 @@ native-compile: compile
 native-dry-api:
 	@sam local start-api --template ./resources/native-template.yml --skip-pull-image
 
-pack: compile
+pack: compile make-bucket
 	@sam package --template-file ./template.yml --output-template-file packaged.yaml --s3-bucket $(BUCKET_NAME) --s3-prefix "hello-lambda-latest"
 
 deploy: pack
 	@sam deploy --template-file ./packaged.yaml --stack-name $(STACK_NAME) --capabilities CAPABILITY_IAM --region $(APP_REGION)
 
-native-pack: native-compile
+native-pack: native-compile make-bucket
 	@sam package --template-file ./resources/native-template.yml --output-template-file resources/native-packaged.yaml --s3-bucket $(BUCKET_NAME) --s3-prefix "hello-lambda-latest"
 
 native-deploy: native-pack

--- a/examples/hello-lambda/README.md
+++ b/examples/hello-lambda/README.md
@@ -1,0 +1,21 @@
+# Prerequisites
+
+- aws
+- sam
+
+## Additional prerequisites for building native lambdas:
+
+- choly
+- Docker
+
+# Unoptimized, JVM version
+
+```
+make clean deploy
+```
+
+# Optimized, Graalified native version:
+
+```
+make clean native-deploy
+```

--- a/examples/hello-lambda/src/hello_lambda/core.clj
+++ b/examples/hello-lambda/src/hello_lambda/core.clj
@@ -9,7 +9,7 @@
   (h/info "Event body" event)
   (h/info "Event context" context)
   {:statusCode 200
-   :body {:message "Hello"
+   :body {:message "Hello from Eugene Koontz`!!!!! Heerlijke kerst!! .."
           "it's" "me"
           :you "looking"
           :for true}

--- a/examples/hello-lambda/src/hello_lambda/core.clj
+++ b/examples/hello-lambda/src/hello_lambda/core.clj
@@ -9,7 +9,7 @@
   (h/info "Event body" event)
   (h/info "Event context" context)
   {:statusCode 200
-   :body {:message "Hello from Eugene Koontz`!!!!! Heerlijke kerst!! .."
+   :body {:message "Hello"
           "it's" "me"
           :you "looking"
           :for true}


### PR DESCRIPTION
- Add `README.md` with Prerequisites and build steps for java and native deployments
- Add dependencies so that both kinds of deployments work with intermediate steps automatically taken
- Add `clean` makefile target
- `make_bucket` checks for existence of bucket before attempting to create
- Use `.yml` as extension suffix for YAML files consistently
