### PR TITLE
use java8 (not java11) for runtime for JVM lambdas to avoid 'java.lan…

### DIFF
--- a/examples/hello-lambda/template.yml
+++ b/examples/hello-lambda/template.yml
@@ -6,7 +6,7 @@ Description: >
 Parameters:
   Runtime:
     Type: String
-    Default: java11
+    Default: java8
   Timeout:
     Type: Number
     Default: 40


### PR DESCRIPTION
…g.ExceptionInInitializerError'

Fix for https://github.com/FieryCod/holy-lambda/issues/26 
cc @burinc