### PR TITLE
Update clj-new invocation

### DIFF
--- a/docs/project-scaffolding.md
+++ b/docs/project-scaffolding.md
@@ -2,7 +2,7 @@
 > :information_source: Make sure that you have [clj-new](https://github.com/seancorfield/clj-new#getting-started) installed
 
 ``` clojure
-clojure -M:new -m clj-new.create holy-lambda basic.example && cd basic.example && bb hl:sync
+clojure -Tclj-new create :template holy-lambda :name basic.example && cd basic.example && bb hl:babashka:sync
 ```
 
 Alternatively you can use `lein new`:

--- a/docs/project-scaffolding.md
+++ b/docs/project-scaffolding.md
@@ -2,7 +2,7 @@
 > :information_source: Make sure that you have [clj-new](https://github.com/seancorfield/clj-new#getting-started) installed
 
 ``` clojure
-clojure -Tclj-new create :template holy-lambda :name basic.example && cd basic.example && bb hl:babashka:sync
+clojure -Tclj-new create :template holy-lambda :name basic.example
 ```
 
 Alternatively you can use `lein new`:


### PR DESCRIPTION
Both the clj-new invocation and the bb task were out-of-date. 

```
❯ clojure -M:new -m clj-new.create holy-lambda basic.example
Execution error (FileNotFoundException) at clojure.main/main (main.java:40).
Could not locate clj_new/create__init.class, clj_new/create.clj or clj_new/create.cljc on classpath. Please check that namespaces with dashes use underscores in the Clojure file name.
```

```
❯ bb hl:sync
----- Error --------------------------------------------------------------------
Type:     java.lang.Exception
Message:  File does not exist: hl:sync
```