### PR TITLE
locate generated class files under .holy-lambda/target

### DIFF
--- a/modules/holy-lambda-template/resources/leiningen/new/holy_lambda/build.clj
+++ b/modules/holy-lambda-template/resources/leiningen/new/holy_lambda/build.clj
@@ -2,11 +2,11 @@
   (:require
    [clojure.tools.build.api :as b]))
 
-(def class-dir "target/classes")
+(def class-dir ".holy-lambda/target/classes")
 (def basis (b/create-basis {:project "deps.edn"}))
 
 (defn clean [_]
-  (b/delete {:path "target"})
+  (b/delete {:path ".holy-lambda/target"})
   (b/delete {:path ".holy-lambda/build"}))
 
 (defn uber [_]

--- a/modules/holy-lambda-template/resources/leiningen/new/holy_lambda/deps.edn
+++ b/modules/holy-lambda-template/resources/leiningen/new/holy_lambda/deps.edn
@@ -5,4 +5,5 @@
  :paths  ["src" "resources"]
  :aliases
  {:build {:deps {io.github.clojure/tools.build {:git/tag "v0.8.3" :git/sha "0d20256"}}
-          :ns-default build}}}
+          :ns-default build
+          :jvm-opts ["-Dclojure.compiler.direct-linking=true" "-Dclojure.spec.skip-macros=true"]}}}


### PR DESCRIPTION
I placed `target` under `.holy-lambda`. That way, the top-level directory is tidier, and `bb hl:clean` works as is.